### PR TITLE
Fix invalid block

### DIFF
--- a/datamodel.itomig-webhook-integration.xml
+++ b/datamodel.itomig-webhook-integration.xml
@@ -353,10 +353,7 @@
 
 
     if ($this->Get('include_userinfo') == 'yes') {
-      /**
-       * Add user info
-       * @var User $oUser
-       */
+      // Add user info
       $oUser = UserRights::GetUserObject();
       $oContact = $oUser->GetContactObject() ?: $oUser;
       $sContactUrl = ApplicationContext::MakeObjectUrl(get_class($oContact), $oContact->GetKey(), null, false);

--- a/datamodel.itomig-webhook-integration.xml
+++ b/datamodel.itomig-webhook-integration.xml
@@ -325,16 +325,18 @@
     $sText = empty($this->Get("text")) ? "" : $this->prepareTextForSlack(MetaModel::ApplyParams($this->Get("text"), $aContextArgs));
     $aSlackData = array(
       'text' => $sText,
-      'blocks' => array(
-        array(
-          'type' => 'section',
-          'text' => array(
-            'type' => 'mrkdwn',
-            'text' => $sText,
-          ),
-        ),
-      ),
+      'blocks' => array(),
     );
+
+    if (!empty($sText)) {
+      $aSlackData['blocks'][] = array(
+        'type' => 'section',
+        'text' => array(
+          'type' => 'mrkdwn',
+          'text' => $sText,
+        ),
+      );
+    }
 
     if (!empty($this->Get('channel'))) {
       $aSlackData['channel'] = $this->Get('channel');


### PR DESCRIPTION
If the text is empty, Slack would fail the notification with error 400 invalid block.

So the fix is to not put a block with empty text in that case.